### PR TITLE
Integrate external data into form runner

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,11 @@
   background-color: #f8fafc;
 }
 
+html,
+body {
+  height: 100%;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -12,16 +17,20 @@
 body {
   margin: 0;
   min-height: 100vh;
+  overflow: hidden;
 }
 
 #root {
   min-height: 100vh;
+  height: 100%;
 }
 
 .app {
   min-height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
 }
 
 .app header {
@@ -72,6 +81,7 @@ body {
 
 .designer-view {
   flex: 1;
+  min-height: 0;
   display: grid;
   grid-template-columns: 250px minmax(0, 1fr) 320px;
   gap: 1rem;
@@ -326,6 +336,26 @@ button.danger:hover {
   background: #ecfeff;
   color: #0f172a;
   border: 1px solid #22d3ee;
+}
+
+.external-data-banner {
+  margin: 1rem 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  font-size: 0.9rem;
+}
+
+.external-data-banner.info {
+  background: #e0f2fe;
+  color: #0f172a;
+  border-color: #38bdf8;
+}
+
+.external-data-banner.error {
+  background: #fee2e2;
+  color: #b91c1c;
+  border-color: #fca5a5;
 }
 
 .form-node {

--- a/src/utils/externalData.ts
+++ b/src/utils/externalData.ts
@@ -1,0 +1,256 @@
+import type { FormField } from '../types';
+
+export interface ExternalDataFetchResult {
+  payload: unknown;
+  isFallback: boolean;
+}
+
+export interface ProcessedExternalData {
+  selectOptions: Record<string, string[]>;
+  initialValues: Record<string, unknown>;
+}
+
+const demoDatasets: Record<string, unknown> = {
+  'https://api.example.com/customers': {
+    'field-company': 'Aurora Industries',
+    'field-quantity': 25,
+    options: ['Aurora Industries', 'Nordic Solutions', 'Helio Labs', 'Svea Partners'],
+  },
+};
+
+const labelKeys = ['label', 'name', 'title', 'value', 'id', 'code'];
+
+const sanitizeKey = (key: string) => key.replace(/[\s_-]+/g, '').toLowerCase();
+
+const createKeyVariants = (input: string) => {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return [] as string[];
+  }
+
+  const camel = trimmed
+    .toLowerCase()
+    .replace(/[-_\s]+([a-z0-9])/gi, (_, char: string) => char.toUpperCase());
+
+  const variants = new Set<string>([
+    trimmed,
+    trimmed.toLowerCase(),
+    trimmed.replace(/[-_\s]+/g, ''),
+    trimmed.replace(/[-_\s]+/g, '_'),
+    camel,
+    camel.toLowerCase(),
+    sanitizeKey(trimmed),
+  ]);
+
+  return Array.from(variants).filter(Boolean);
+};
+
+const toOptionValue = (input: unknown): string | null => {
+  if (input == null) {
+    return null;
+  }
+
+  if (typeof input === 'string' || typeof input === 'number' || typeof input === 'boolean') {
+    return String(input);
+  }
+
+  if (Array.isArray(input)) {
+    return null;
+  }
+
+  if (typeof input === 'object') {
+    for (const key of labelKeys) {
+      const value = (input as Record<string, unknown>)[key];
+      if (value == null) continue;
+      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+      }
+    }
+
+    const firstKey = Object.keys(input as Record<string, unknown>)[0];
+    if (firstKey) {
+      const value = (input as Record<string, unknown>)[firstKey];
+      if (value == null) return null;
+      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+      }
+    }
+  }
+
+  return null;
+};
+
+const buildLookup = (record: Record<string, unknown>) => {
+  const lower = new Map<string, unknown>();
+  const sanitized = new Map<string, unknown>();
+
+  Object.entries(record).forEach(([key, value]) => {
+    lower.set(key.toLowerCase(), value);
+    sanitized.set(sanitizeKey(key), value);
+  });
+
+  return { lower, sanitized } as const;
+};
+
+const getValueFromRecord = (
+  record: Record<string, unknown>,
+  lookup: ReturnType<typeof buildLookup>,
+  keys: string[],
+  predicate?: (value: unknown) => boolean
+): unknown => {
+  for (const key of keys) {
+    if (key in record) {
+      const value = record[key];
+      if (!predicate || predicate(value)) {
+        return value;
+      }
+    }
+  }
+
+  for (const key of keys) {
+    const value = lookup.lower.get(key.toLowerCase());
+    if (value === undefined) continue;
+    if (!predicate || predicate(value)) {
+      return value;
+    }
+  }
+
+  for (const key of keys) {
+    const value = lookup.sanitized.get(sanitizeKey(key));
+    if (value === undefined) continue;
+    if (!predicate || predicate(value)) {
+      return value;
+    }
+  }
+
+  return undefined;
+};
+
+const normalizeOptions = (input: unknown[]): string[] => {
+  const seen = new Set<string>();
+  const options: string[] = [];
+  input.forEach((item) => {
+    const candidate = toOptionValue(item);
+    if (!candidate || seen.has(candidate)) return;
+    seen.add(candidate);
+    options.push(candidate);
+  });
+  return options;
+};
+
+const convertInitialValue = (field: FormField, value: unknown): unknown | undefined => {
+  if (value == null) return undefined;
+
+  if (field.type === 'number') {
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? value : undefined;
+    }
+    if (typeof value === 'string' && value.trim() !== '') {
+      const numeric = Number(value);
+      return Number.isFinite(numeric) ? numeric : undefined;
+    }
+    return undefined;
+  }
+
+  if (field.type === 'select') {
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      return String(value);
+    }
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  return undefined;
+};
+
+const getArrayValue = (
+  record: Record<string, unknown>,
+  lookup: ReturnType<typeof buildLookup>,
+  keys: string[]
+): unknown[] | undefined => {
+  const value = getValueFromRecord(record, lookup, keys, Array.isArray);
+  return Array.isArray(value) ? value : undefined;
+};
+
+export async function loadExternalData(url: string, signal?: AbortSignal): Promise<ExternalDataFetchResult> {
+  try {
+    const response = await fetch(url, { signal });
+    if (!response.ok) {
+      throw new Error(`Servern svarade med status ${response.status}`);
+    }
+
+    const payload = await response.json();
+    return { payload, isFallback: false };
+  } catch (error) {
+    if (signal?.aborted) {
+      throw error;
+    }
+
+    if (url in demoDatasets) {
+      return { payload: demoDatasets[url], isFallback: true };
+    }
+
+    throw error;
+  }
+}
+
+export function processExternalData(payload: unknown, fields: FormField[]): ProcessedExternalData {
+  const selectOptions: Record<string, string[]> = {};
+  const initialValues: Record<string, unknown> = {};
+
+  if (Array.isArray(payload)) {
+    const options = normalizeOptions(payload);
+    if (options.length > 0) {
+      fields
+        .filter((field) => field.type === 'select')
+        .forEach((field) => {
+          selectOptions[field.id] = options;
+        });
+    }
+
+    return { selectOptions, initialValues };
+  }
+
+  if (payload && typeof payload === 'object') {
+    const record = payload as Record<string, unknown>;
+    const lookup = buildLookup(record);
+
+    const genericArray = getArrayValue(record, lookup, ['options', 'values', 'items', 'data', 'list']);
+
+    fields.forEach((field) => {
+      const keyVariants = [...createKeyVariants(field.id), ...createKeyVariants(field.label ?? '')];
+
+      const rawValue = getValueFromRecord(record, lookup, keyVariants);
+      const initialValue = convertInitialValue(field, rawValue);
+      if (initialValue !== undefined) {
+        initialValues[field.id] = initialValue;
+      }
+
+      if (field.type === 'select') {
+        const optionKeys = keyVariants.flatMap((variant) => [
+          `${variant}Options`,
+          `${variant}_options`,
+          `${variant}List`,
+          `${variant}_list`,
+        ]);
+
+        const optionArray = getArrayValue(record, lookup, optionKeys) ?? genericArray;
+        if (optionArray) {
+          const options = normalizeOptions(optionArray);
+          if (options.length > 0) {
+            selectOptions[field.id] = options;
+          }
+        }
+      }
+    });
+  }
+
+  return { selectOptions, initialValues };
+}


### PR DESCRIPTION
## Summary
- add utilities for loading and transforming external node data, including a demo dataset fallback
- enhance the form runner to fetch node data, hydrate select options or initial values, and surface loading/error banners
- confine page scrolling to the app container and style the new external data messaging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3eac9fa6883219b640435ec6e9731