### PR TITLE
Handle field-level external data and add form export

### DIFF
--- a/src/components/NodeInspector.tsx
+++ b/src/components/NodeInspector.tsx
@@ -94,20 +94,6 @@ export default function NodeInspector({ node, onChange }: NodeInspectorProps) {
           }
         />
       </label>
-      <label>
-        Extern datakälla (URL)
-        <input
-          value={data.externalDataUrl ?? ''}
-          placeholder="https://..."
-          onChange={(event) =>
-            onChange((current) => ({
-              ...current,
-              externalDataUrl: event.target.value,
-            }))
-          }
-        />
-      </label>
-
       <section className="inspector-section">
         <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <h3 style={{ margin: 0 }}>Formulärfält</h3>
@@ -170,6 +156,17 @@ export default function NodeInspector({ node, onChange }: NodeInspectorProps) {
                     value={field.placeholder ?? ''}
                     onChange={(event) => updateField(field.id, { placeholder: event.target.value })}
                   />
+                </label>
+                <label style={{ gridColumn: '1 / -1' }}>
+                  Extern datakälla (URL)
+                  <input
+                    value={field.externalDataUrl ?? ''}
+                    placeholder="https://..."
+                    onChange={(event) => updateField(field.id, { externalDataUrl: event.target.value })}
+                  />
+                  <span className="field-hint">
+                    Använd en extern källa för att hämta initialvärden och eventuella listalternativ.
+                  </span>
                 </label>
                 {field.type === 'select' ? (
                   <label>

--- a/src/components/nodes/FormNode.tsx
+++ b/src/components/nodes/FormNode.tsx
@@ -5,22 +5,36 @@ import type { FormNodeData } from '../../types';
 const handleStyle = { width: 12, height: 12, borderRadius: 999, border: '2px solid white' } as const;
 
 function FormNodeComponent({ data, selected }: NodeProps<FormNodeData>) {
+  const fieldsWithExternalData = data.fields.filter((field) => field.externalDataUrl?.trim());
+  const hasExternalData = fieldsWithExternalData.length > 0;
+
   return (
     <div className={`form-node ${selected ? 'selected' : ''} ${data.variant === 'decision-step' ? 'decision' : ''}`}>
       <Handle type="target" position={Position.Top} style={{ ...handleStyle, background: '#0f172a' }} />
-      <Handle
-        type="target"
-        id="external-data"
-        position={Position.Left}
-        style={{ ...handleStyle, background: '#475569', top: '50%' }}
-      />
-      <span className="data-handle-label">Extern data</span>
+      {hasExternalData ? (
+        <>
+          <Handle
+            type="target"
+            id="external-data"
+            position={Position.Left}
+            style={{ ...handleStyle, background: '#475569', top: '50%' }}
+          />
+          <span className="data-handle-label">Extern data</span>
+        </>
+      ) : null}
       <h3>{data.title}</h3>
       {data.description ? <p>{data.description}</p> : null}
-      {data.externalDataUrl ? (
-        <p style={{ fontSize: '0.75rem', color: '#0f172a', marginTop: '0.35rem' }}>
-          Kopplad mot <strong>{data.externalDataUrl}</strong>
-        </p>
+      {hasExternalData ? (
+        <div className="form-node-external">
+          <strong>Extern data</strong>
+          <ul>
+            {fieldsWithExternalData.map((field) => (
+              <li key={field.id}>
+                {field.label}: <span>{field.externalDataUrl}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
       ) : null}
       {data.fields.length > 0 ? (
         <div className="fields">
@@ -29,6 +43,7 @@ function FormNodeComponent({ data, selected }: NodeProps<FormNodeData>) {
             {data.fields.map((field) => (
               <li key={field.id}>
                 {field.label} ({field.type}){field.required ? ' *' : ''}
+                {field.externalDataUrl ? <span className="field-chip">Extern</span> : null}
               </li>
             ))}
           </ul>

--- a/src/index.css
+++ b/src/index.css
@@ -204,6 +204,14 @@ body {
   gap: 0.5rem;
 }
 
+.field-hint {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #475569;
+}
+
 .field-actions,
 .outcome-actions {
   display: flex;
@@ -278,6 +286,12 @@ button.danger:hover {
 }
 
 .form-runner form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.form-runner form .field-label-text {
   font-weight: 600;
 }
 
@@ -288,6 +302,22 @@ button.danger:hover {
   border-radius: 0.6rem;
   border: 1px solid #cbd5f5;
   font-size: 0.95rem;
+  width: 100%;
+}
+
+.field-inline-note {
+  display: block;
+  font-size: 0.8rem;
+  color: #475569;
+  font-weight: 400;
+}
+
+.field-inline-note.info {
+  color: #1d4ed8;
+}
+
+.field-inline-note.error {
+  color: #b91c1c;
 }
 
 .form-runner form input:focus,
@@ -386,10 +416,41 @@ button.danger:hover {
   color: #334155;
 }
 
+.form-node-external {
+  margin-top: 0.5rem;
+  background: rgba(71, 85, 105, 0.12);
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
+  color: #0f172a;
+}
+
+.form-node-external ul {
+  margin: 0.35rem 0 0;
+  padding-left: 1rem;
+}
+
+.form-node-external li span {
+  color: #1d4ed8;
+  word-break: break-word;
+}
+
 .form-node .fields {
   margin-top: 0.75rem;
   font-size: 0.8rem;
   color: #475569;
+}
+
+.field-chip {
+  margin-left: 0.4rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  background: #dbeafe;
+  color: #1d4ed8;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
 .outcome-label {
@@ -429,6 +490,24 @@ button.danger:hover {
 .submission-settings h2 {
   margin: 0 0 0.75rem;
   font-size: 1rem;
+}
+
+.save-form-button {
+  margin-top: 0.75rem;
+  width: 100%;
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.65rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: #4f46e5;
+  color: white;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.save-form-button:hover {
+  background: #4338ca;
+  box-shadow: 0 12px 28px rgba(79, 70, 229, 0.35);
 }
 
 @media (max-width: 1100px) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface FormField {
   required: boolean;
   placeholder?: string;
   options?: string[];
+  externalDataUrl?: string;
 }
 
 export interface NodeOutcome {
@@ -22,7 +23,6 @@ export interface FormNodeData {
   description?: string;
   variant: 'form-step' | 'decision-step';
   fields: FormField[];
-  externalDataUrl?: string;
   outcomes: NodeOutcome[];
 }
 


### PR DESCRIPTION
## Summary
- allow external data sources to be configured directly on fields and surface their status in the designer and runner
- refactor the form runner to fetch per-field data for select options and initial values while keeping users informed
- add a save button to export the current flow definition as JSON and tweak styling for the new controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3f5bc6f9083218f70543523a87289