### PR TITLE
Add form import support and improve external data handling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -492,6 +492,35 @@ button.danger:hover {
   font-size: 1rem;
 }
 
+.submission-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.submission-actions button {
+  width: 100%;
+}
+
+.submission-actions .save-form-button {
+  margin-top: 0;
+}
+
+.submission-feedback {
+  font-size: 0.85rem;
+  margin-top: 0.5rem;
+  font-weight: 600;
+}
+
+.submission-feedback.success {
+  color: #15803d;
+}
+
+.submission-feedback.error {
+  color: #b91c1c;
+}
+
 .save-form-button {
   margin-top: 0.75rem;
   width: 100%;

--- a/src/utils/externalData.ts
+++ b/src/utils/externalData.ts
@@ -241,7 +241,12 @@ export function processExternalData(payload: unknown, fields: FormField[]): Proc
           `${variant}_list`,
         ]);
 
-        const optionArray = getArrayValue(record, lookup, optionKeys) ?? genericArray;
+        let optionArray = getArrayValue(record, lookup, optionKeys) ?? genericArray;
+
+        if (!optionArray && Array.isArray(rawValue)) {
+          optionArray = rawValue;
+        }
+
         if (optionArray) {
           const options = normalizeOptions(optionArray);
           if (options.length > 0) {


### PR DESCRIPTION
## Summary
- add a JSON import flow in the designer so saved forms can be restored
- update submission settings UI with import feedback messaging
- fix external select field processing to prefer fetched option arrays over demo data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4005654788321a272d0a1bc4eb8d7