### PR TITLE
feat: add wildcard paths and value mapping for external data

### DIFF
--- a/src/components/NodeInspector.tsx
+++ b/src/components/NodeInspector.tsx
@@ -182,6 +182,21 @@ export default function NodeInspector({ node, onChange }: NodeInspectorProps) {
                   </span>
                 </label>
                 {field.type === 'select' ? (
+                  <label style={{ gridColumn: '1 / -1' }}>
+                    JSON-sökväg till alternativens värde (value)
+                    <input
+                      value={field.externalDataValuePath ?? ''}
+                      placeholder="t.ex. data.items[].id"
+                      onChange={(event) => updateField(field.id, { externalDataValuePath: event.target.value })}
+                      disabled={!field.externalDataUrl?.trim()}
+                    />
+                    <span className="field-hint">
+                      Använd en separat sökväg för tekniska värden om listalternativen kräver ett annat värde än den
+                      synliga texten.
+                    </span>
+                  </label>
+                ) : null}
+                {field.type === 'select' ? (
                   <label>
                     Alternativ (ett per rad)
                     <textarea

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,12 @@ export interface FormField {
   options?: string[];
   externalDataUrl?: string;
   externalDataPath?: string;
+  externalDataValuePath?: string;
+}
+
+export interface SelectOption {
+  value: string;
+  label: string;
 }
 
 export interface NodeOutcome {


### PR DESCRIPTION
## Summary
- allow external data lookups to resolve values from every element in an array via [] path segments
- return structured select options with separate labels/values and honor dedicated value paths
- expose configuration for select value paths in the node inspector and render options with label/value pairs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d62b0ff504832189066d559981dac7