### PR TITLE
Add search and filter controls to node palette

### DIFF
--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -1,9 +1,12 @@
-import type { DragEvent } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import type { ChangeEvent, DragEvent } from 'react';
 
 interface PaletteItem {
   type: 'form-step' | 'decision-step';
   title: string;
   description: string;
+  category: string;
+  subcategory: string;
 }
 
 const items: PaletteItem[] = [
@@ -11,34 +14,135 @@ const items: PaletteItem[] = [
     type: 'form-step',
     title: 'Formulärsteg',
     description: 'Samla in information från användaren.',
+    category: 'Interaktion',
+    subcategory: 'Formulär',
   },
   {
     type: 'decision-step',
     title: 'Beslutssteg',
     description: 'Grenar baserat på användarens val.',
+    category: 'Logik',
+    subcategory: 'Vägval',
   },
 ];
 
+const ALL_VALUE = 'all';
+
 export default function NodePalette() {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState<string>(ALL_VALUE);
+  const [subcategoryFilter, setSubcategoryFilter] = useState<string>(ALL_VALUE);
+
+  const categories = useMemo(() => {
+    const unique = new Set(items.map((item) => item.category));
+    return [ALL_VALUE, ...unique];
+  }, []);
+
+  const availableSubcategories = useMemo(() => {
+    const relevantItems = items.filter(
+      (item) => categoryFilter === ALL_VALUE || item.category === categoryFilter,
+    );
+    const unique = new Set(relevantItems.map((item) => item.subcategory));
+    return [ALL_VALUE, ...unique];
+  }, [categoryFilter]);
+
+  useEffect(() => {
+    if (subcategoryFilter !== ALL_VALUE && !availableSubcategories.includes(subcategoryFilter)) {
+      setSubcategoryFilter(ALL_VALUE);
+    }
+  }, [availableSubcategories, subcategoryFilter]);
+
+  const filteredItems = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+
+    return items.filter((item) => {
+      if (categoryFilter !== ALL_VALUE && item.category !== categoryFilter) {
+        return false;
+      }
+
+      if (subcategoryFilter !== ALL_VALUE && item.subcategory !== subcategoryFilter) {
+        return false;
+      }
+
+      if (!query) {
+        return true;
+      }
+
+      const haystack = `${item.title} ${item.description}`.toLowerCase();
+      return haystack.includes(query);
+    });
+  }, [categoryFilter, subcategoryFilter, searchTerm]);
+
   const onDragStart = (event: DragEvent<HTMLDivElement>, nodeType: PaletteItem['type']) => {
     event.dataTransfer.setData('application/reactflow', nodeType);
     event.dataTransfer.effectAllowed = 'move';
   };
 
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(event.target.value);
+  };
+
+  const handleCategoryChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setCategoryFilter(event.target.value);
+  };
+
+  const handleSubcategoryChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setSubcategoryFilter(event.target.value);
+  };
+
   return (
     <aside className="palette">
       <h2>Byggstenar</h2>
-      {items.map((item) => (
-        <div
-          key={item.type}
-          className="palette-item"
-          onDragStart={(event) => onDragStart(event, item.type)}
-          draggable
-        >
-          <strong>{item.title}</strong>
-          <span>{item.description}</span>
+
+      <div className="palette-controls">
+        <input
+          type="search"
+          placeholder="Sök efter komponenter"
+          value={searchTerm}
+          onChange={handleSearchChange}
+        />
+
+        <div className="palette-filters">
+          <label>
+            <span>Kategori</span>
+            <select value={categoryFilter} onChange={handleCategoryChange}>
+              {categories.map((category) => (
+                <option key={category} value={category}>
+                  {category === ALL_VALUE ? 'Alla kategorier' : category}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label>
+            <span>Delkategori</span>
+            <select value={subcategoryFilter} onChange={handleSubcategoryChange}>
+              {availableSubcategories.map((subcategory) => (
+                <option key={subcategory} value={subcategory}>
+                  {subcategory === ALL_VALUE ? 'Alla delkategorier' : subcategory}
+                </option>
+              ))}
+            </select>
+          </label>
         </div>
-      ))}
+      </div>
+
+      {filteredItems.length === 0 ? (
+        <p className="palette-empty-state">Inga komponenter matchar dina filter.</p>
+      ) : (
+        filteredItems.map((item) => (
+          <div
+            key={item.type}
+            className="palette-item"
+            onDragStart={(event) => onDragStart(event, item.type)}
+            draggable
+          >
+            <strong>{item.title}</strong>
+            <span>{item.description}</span>
+          </div>
+        ))
+      )}
+
       <p style={{ fontSize: '0.75rem', color: '#64748b', marginTop: '0.75rem' }}>
         Dra en komponent och släpp den i arbetsytan för att skapa nya steg.
       </p>

--- a/src/index.css
+++ b/src/index.css
@@ -108,6 +108,58 @@ body {
   font-size: 1rem;
 }
 
+.palette-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.palette-controls input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
+  font-size: 0.9rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.palette-controls input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.palette-filters {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.palette-filters label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  flex: 1 1 140px;
+  font-size: 0.75rem;
+  color: #475569;
+}
+
+.palette-filters select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
+  font-size: 0.9rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.palette-filters select:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
 .palette-item {
   background: #f1f5f9;
   padding: 0.75rem;
@@ -125,6 +177,16 @@ body {
 .palette-item strong {
   display: block;
   margin-bottom: 0.35rem;
+}
+
+.palette-empty-state {
+  margin: 0.5rem 0;
+  padding: 0.75rem;
+  background: #f1f5f9;
+  border-radius: 0.75rem;
+  color: #475569;
+  font-size: 0.85rem;
+  text-align: center;
 }
 
 .designer-canvas {


### PR DESCRIPTION
## Summary
- add category and subcategory metadata to palette items and expose filtering UI
- provide a search field that matches palette titles and descriptions
- enhance palette styling for the new controls and empty state messaging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fbab4950a08321bfeaaa225ea4d0d7